### PR TITLE
Formset-in-forms

### DIFF
--- a/fast_gov_uk/design_system/contrib.py
+++ b/fast_gov_uk/design_system/contrib.py
@@ -46,12 +46,10 @@ class NumberInput(TextInput):
 
     @property
     async def clean(self):
-        if self.value:
-            try:
-                number = int(self.value)
-                return number
-            except ValueError:
-                return None
+        if not self.value:
+            return None
+        number = int(self.value)
+        return number
 
 
 @dataclass
@@ -77,9 +75,7 @@ class DecimalInput(TextInput):
 
     @property
     async def clean(self):
-        if self.value:
-            try:
-                number = float(self.value)
-                return number
-            except ValueError:
-                return None
+        if not self.value:
+            return None
+        number = float(self.value)
+        return number

--- a/fast_gov_uk/design_system/inputs.py
+++ b/fast_gov_uk/design_system/inputs.py
@@ -942,26 +942,29 @@ def CookieBanner(
     )
 
 
-def Fieldset(
-    legend: str,
-    *children: Field,
-) -> fh.FT:
+class Fieldset(AbstractField):
     """
     Fieldset component.
     Args:
+        fields (list): Fields to include in the fieldset.
         legend (str): The legend text for the fieldset.
-        *children (Field): Child components to include in the fieldset.
     Returns:
         FT: A FastHTML Fieldset component.
     """
-    return fh.Fieldset(
-        fh.Legend(
-            fh.H1(
-                legend,
-                cls="govuk-fieldset__heading",
+
+    def __init__(self, *fields: Field, legend: str = ""):
+        self.fields = fields
+        self.legend = legend
+
+    def __ft__(self):
+        return fh.Fieldset(
+            fh.Legend(
+                fh.H1(
+                    self.legend,
+                    cls="govuk-fieldset__heading",
+                ),
+                cls="govuk-fieldset__legend govuk-fieldset__legend--l",
             ),
-            cls="govuk-fieldset__legend govuk-fieldset__legend--l",
-        ),
-        *children,
-        cls="govuk-fieldset",
-    )
+            *self.fields,
+            cls="govuk-fieldset",
+        )

--- a/fast_gov_uk/design_system/inputs.py
+++ b/fast_gov_uk/design_system/inputs.py
@@ -66,8 +66,12 @@ def Error(field_id: str, text: str, extra_cls: str = "") -> fh.FT:
     )
 
 
+class AbstractField:
+    pass
+
+
 @dataclass
-class Field:
+class Field(AbstractField):
     """
     Baseclass for form fields.
     Args:
@@ -422,7 +426,7 @@ class TextInput(Field):
 
 
 @dataclass
-class Checkbox:
+class Checkbox(AbstractField):
     """
     Checkbox component. This component does not inherit from Field because
     (at this moment), the primary usage for this is as an API to define
@@ -534,7 +538,7 @@ class Checkboxes(Field):
 
 
 @dataclass
-class Radio:
+class Radio(AbstractField):
     """
     Radio component. This component does not inherit from Field because
     (at this moment), the primary usage for this is as an API to define

--- a/fast_gov_uk/design_system/inputs.py
+++ b/fast_gov_uk/design_system/inputs.py
@@ -731,19 +731,22 @@ class DateInput(Field):
 
     @property
     async def clean(self):
+        # Field not required
+        if not self.value:
+            return None
         try:
             day, month, year = self.value
             day, month, year = int(day), int(month), int(year)
             _date = date(day=day, month=month, year=year)
             return _date.isoformat()
         except ValueError:
-            return None
+            raise
 
     @value.setter
     def value(self, value):
         self._value = value
         day, month, year = self._value
-        if not day or not month or not year:
+        if self.required and (not day or not month or not year):
             self.error = "This field is required."
             return
         try:

--- a/fast_gov_uk/design_system/inputs.py
+++ b/fast_gov_uk/design_system/inputs.py
@@ -938,7 +938,7 @@ def CookieBanner(
         role="region",
         aria_label=f"Cookies on {service_name}",
         data_nosnippet=True,
-        _id="cookie-banner",
+        id="cookie-banner",
     )
 
 

--- a/fast_gov_uk/tests/app.py
+++ b/fast_gov_uk/tests/app.py
@@ -21,10 +21,17 @@ def profile(data=None):
         title="Create a Profile",
         fields=[
             ds.TextInput("name", "What is your name?"),
-            ds.Radios(
-                name="gender",
-                label="What is your gender?",
-                choices=["Male", "Female", "Prefer not to say"],
+            ds.Fieldset(
+                ds.Radios(
+                    name="sex",
+                    label="What is your sex?",
+                    choices=["Male", "Female", "Prefer not to say"],
+                ),
+                ds.Radios(
+                    name="gender",
+                    label="Is your gender the same as your sex?",
+                    choices=["Yes", "No", "Prefer not to say"],
+                ),
             ),
             ds.Radios(
                 name="ethnicity",

--- a/fast_gov_uk/tests/conftest.py
+++ b/fast_gov_uk/tests/conftest.py
@@ -5,6 +5,8 @@ import pytest
 from bs4 import BeautifulSoup
 from fasthtml import common as fh
 
+from fast_gov_uk.design_system import AbstractField
+
 
 @pytest.fixture
 def fast():
@@ -33,8 +35,13 @@ def picture():
 
 @pytest.fixture
 def html():
-    def pretty_html(component):
-        html_str = str(component)
+    def pretty_html(x):
+        if isinstance(x, AbstractField):
+            html_str = fh.to_xml(x)
+        elif isinstance(x, fh.FT):
+            html_str = str(x)
+        else:
+            html_str = x
         soup = BeautifulSoup(html_str, "html.parser")
         return soup.prettify()
     return pretty_html

--- a/fast_gov_uk/tests/design_system/test_contrib.py
+++ b/fast_gov_uk/tests/design_system/test_contrib.py
@@ -13,14 +13,14 @@ import fast_gov_uk.design_system as ds
         "test@",
     ),
 )
-def test_emailinput_invalid(value):
+def test_emailinput_invalid(value, html):
     """Test EmailInput with various parameters.
     Args:
         value (str): The value to assign to EmailInput.
     """
     email = ds.EmailInput(name="test")
     email.value = value
-    assert fh.to_xml(email, indent=False) == (
+    assert html(email) == html(
         '<div class="govuk-form-group govuk-form-group--error">'
             '<p id="test-error" class="govuk-error-message">'
                 '<span class="govuk-visually-hidden">Error: </span>'
@@ -38,14 +38,14 @@ def test_emailinput_invalid(value):
         "@test",
     ),
 )
-def test_emailinput_valid(value):
+def test_emailinput_valid(value, html):
     """Test EmailInput with various parameters.
     Args:
         value (str): The value to assign to EmailInput.
     """
     email = ds.EmailInput(name="test")
     email.value = value
-    assert fh.to_xml(email, indent=False) == (
+    assert html(email) == html(
         '<div class="govuk-form-group">'
             f'<input type="text" name="test" value="{value}" aria-describedby="test-hint test-error" id="test" class="govuk-input">'
         "</div>"
@@ -60,14 +60,14 @@ def test_emailinput_valid(value):
         "5!",
     ),
 )
-def test_numberinput_invalid(value):
+def test_numberinput_invalid(value, html):
     """Test NumberInput with various parameters.
     Args:
         value (str): The value to assign to NumberInput.
     """
     email = ds.NumberInput(name="test")
     email.value = value
-    assert fh.to_xml(email, indent=False) == (
+    assert html(email) == html(
         '<div class="govuk-form-group govuk-form-group--error">'
             '<p id="test-error" class="govuk-error-message">'
                 '<span class="govuk-visually-hidden">Error: </span>'
@@ -85,14 +85,14 @@ def test_numberinput_invalid(value):
         "0",
     ),
 )
-def test_numberinput_valid(value):
+def test_numberinput_valid(value, html):
     """Test NumberInput with various parameters.
     Args:
         value (str): The value to assign to NumberInput.
     """
     email = ds.NumberInput(name="test")
     email.value = value
-    assert fh.to_xml(email, indent=False) == (
+    assert html(email) == html(
         '<div class="govuk-form-group">'
             f'<input type="text" name="test" value="{value}" aria-describedby="test-hint test-error" id="test" class="govuk-input">'
         "</div>"
@@ -107,14 +107,14 @@ def test_numberinput_valid(value):
         "5!",
     ),
 )
-def test_decimalinput_invalid(value):
+def test_decimalinput_invalid(value, html):
     """Test DecimalInput with various parameters.
     Args:
         value (str): The value to assign to DecimalInput.
     """
     email = ds.DecimalInput(name="test")
     email.value = value
-    assert fh.to_xml(email, indent=False) == (
+    assert html(email) == html(
         '<div class="govuk-form-group govuk-form-group--error">'
             '<p id="test-error" class="govuk-error-message">'
                 '<span class="govuk-visually-hidden">Error: </span>'
@@ -133,14 +133,14 @@ def test_decimalinput_invalid(value):
         "5",
     ),
 )
-def test_decimalinput_valid(value):
+def test_decimalinput_valid(value, html):
     """Test DecimalInput with various parameters.
     Args:
         value (str): The value to assign to DecimalInput.
     """
     email = ds.DecimalInput(name="test")
     email.value = value
-    assert fh.to_xml(email, indent=False) == (
+    assert html(email) == html(
         '<div class="govuk-form-group">'
             f'<input type="text" name="test" value="{value}" aria-describedby="test-hint test-error" id="test" class="govuk-input">'
         "</div>"

--- a/fast_gov_uk/tests/design_system/test_contrib.py
+++ b/fast_gov_uk/tests/design_system/test_contrib.py
@@ -1,4 +1,3 @@
-import fasthtml.common as fh
 import pytest
 
 import fast_gov_uk.design_system as ds

--- a/fast_gov_uk/tests/design_system/test_inputs.py
+++ b/fast_gov_uk/tests/design_system/test_inputs.py
@@ -308,9 +308,9 @@ def test_passwordinput(kwargs, expected, html):
 def test_fieldset(html):
     """Test Fieldset with various parameters."""
     fieldset = ds.Fieldset(
-        "Test Legend",
         fh.P("Test Content 1"),
         fh.P("Test Content 2"),
+        legend="Test Legend",
     )
     expected = (
         '<fieldset class="govuk-fieldset">'

--- a/fast_gov_uk/tests/design_system/test_inputs.py
+++ b/fast_gov_uk/tests/design_system/test_inputs.py
@@ -50,21 +50,21 @@ import fast_gov_uk.design_system as ds
         ),
     ),
 )
-def test_field(kwargs, expected):
+def test_field(kwargs, expected, html):
     """Test Field with various parameters.
     Args:
         kwargs (dict): The arguments to pass to Field.
         expected (str): The expected HTML output.
     """
     field = ds.Field(**kwargs)
-    assert fh.to_xml(field, indent=False) == expected
+    assert html(field) == html(expected)
 
 
-def test_field_required():
+def test_field_required(html):
     """Test Field with required attribute."""
     field = ds.Field("test", label="Test")
     field.value = ""
-    assert fh.to_xml(field, indent=False) == (
+    assert html(field) == html(
         '<div class="govuk-form-group govuk-form-group--error">'
             '<label for="test" class="govuk-label">Test</label>'
             '<p id="test-error" class="govuk-error-message">'
@@ -75,11 +75,11 @@ def test_field_required():
     )
 
 
-def test_field_optional():
+def test_field_optional(html):
     """Test Field with required=False."""
     field = ds.Field("test", label="Test", required=False)
     field.value = ""
-    assert fh.to_xml(field, indent=False) == (
+    assert html(field) == html(
         '<div class="govuk-form-group">'
             '<label for="test" class="govuk-label">Test (Optional)</label>'
         "</div>"
@@ -135,24 +135,24 @@ def test_field_optional():
         ),
     ),
 )
-def test_select(kwargs, expected):
+def test_select(kwargs, expected, html):
     """Test Select with various parameters.
     Args:
         kwargs (dict): The arguments to pass to Select.
         expected (str): The expected HTML output.
     """
     select = ds.Select(**kwargs)
-    assert fh.to_xml(select, indent=False) == expected
+    assert html(select) == html(expected)
 
 
-def test_select_value():
+def test_select_value(html):
     """Test Select with value."""
     select = ds.Select(
         name="test",
         options=[("yes", "Yes"), ("no", "No")],
     )
     select.value = "yes"
-    assert fh.to_xml(select, indent=False) == (
+    assert html(select) == html(
         '<div class="govuk-form-group">'
             '<select name="test" id="test" class="govuk-select">'
                 '<option value="yes" selected>Yes</option>'
@@ -230,14 +230,14 @@ def test_select_value():
         ),
     ),
 )
-def test_textarea(kwargs, expected):
+def test_textarea(kwargs, expected, html):
     """Test Textarea with various parameters.
     Args:
         kwargs (dict): The arguments to pass to Textarea.
         expected (str): The expected HTML output.
     """
     textarea = ds.Textarea(**kwargs)
-    assert fh.to_xml(textarea, indent=False) == expected
+    assert html(textarea) == html(expected)
 
 
 @pytest.mark.parametrize(
@@ -295,17 +295,17 @@ def test_textarea(kwargs, expected):
         ),
     ),
 )
-def test_passwordinput(kwargs, expected):
+def test_passwordinput(kwargs, expected, html):
     """Test PasswordInput with various parameters.
     Args:
         kwargs (dict): The arguments to pass to PasswordInput.
         expected (str): The expected HTML output.
     """
     password = ds.PasswordInput(**kwargs)
-    assert fh.to_xml(password, indent=False) == expected
+    assert html(password) == html(expected)
 
 
-def test_fieldset():
+def test_fieldset(html):
     """Test Fieldset with various parameters."""
     fieldset = ds.Fieldset(
         "Test Legend",
@@ -321,7 +321,7 @@ def test_fieldset():
             "<p>Test Content 2</p>"
         "</fieldset>"
     )
-    assert str(fieldset) == expected
+    assert html(fieldset) == html(expected)
 
 
 @pytest.mark.parametrize(
@@ -398,14 +398,14 @@ def test_fieldset():
         ),
     ),
 )
-def test_charactercount(kwargs, expected):
+def test_charactercount(kwargs, expected, html):
     """Test CharacterCount with various parameters.
     Args:
         kwargs (dict): The arguments to pass to CharacterCount.
         expected (str): The expected HTML output.
     """
     charcount = ds.CharacterCount(**kwargs)
-    assert fh.to_xml(charcount, indent=False) == expected
+    assert html(charcount) == html(expected)
 
 
 @pytest.mark.parametrize(
@@ -437,15 +437,15 @@ def test_charactercount(kwargs, expected):
         ),
     )
 )
-def test_button(kwargs, expected):
+def test_button(kwargs, expected, html):
     """
     Test Table with various parameters.
     """
     button = ds.Button("test1", **kwargs)
-    assert str(button) == expected
+    assert html(button) == html(expected)
 
 
-def test_start_button():
+def test_start_button(html):
     """
     Test Table with various parameters.
     """
@@ -459,7 +459,7 @@ def test_start_button():
             "</svg>"
         "</a>"
     )
-    assert str(start) == expected
+    assert html(start) == html(expected)
 
 
 @pytest.mark.parametrize(
@@ -658,14 +658,14 @@ def test_start_button():
         ),
     ),
 )
-def test_textinput(kwargs, expected):
+def test_textinput(kwargs, expected, html):
     """Test TextInput with various parameters.
     Args:
         kwargs (dict): The arguments to pass to TextInput.
         expected (str): The expected HTML output.
     """
     input = ds.TextInput(**kwargs)
-    assert fh.to_xml(input, indent=False) == expected
+    assert html(input) == html(expected)
 
 
 @pytest.mark.parametrize(
@@ -720,14 +720,14 @@ def test_textinput(kwargs, expected):
         ),
     ),
 )
-def test_checkbox(kwargs, expected):
+def test_checkbox(kwargs, expected, html):
     """Test Checkbox with various parameters.
     Args:
         kwargs (dict): The arguments to pass to Checkbox.
         expected (str): The expected HTML output.
     """
     cb = ds.Checkbox(**kwargs)
-    assert fh.to_xml(cb, indent=False) == expected
+    assert html(cb) == html(expected)
 
 
 @pytest.mark.parametrize(
@@ -840,24 +840,24 @@ def test_checkbox(kwargs, expected):
         ),
     ),
 )
-def test_checkboxes(kwargs, expected):
+def test_checkboxes(kwargs, expected, html):
     """Test Checkboxes with various parameters.
     Args:
         kwargs (dict): The kwargs to pass to Checkboxes.
         expected (str): The expected HTML output.
     """
     cbs = ds.Checkboxes(**kwargs)
-    assert fh.to_xml(cbs, indent=False) == expected
+    assert html(cbs) == html(expected)
 
 
-def test_checkboxes_value():
+def test_checkboxes_value(html):
     """Test Checkboxes with value."""
     checks = ds.Checkboxes(
         name="test",
         checkboxes=[ds.Checkbox("test", "yes", "Yes"), ds.Checkbox("test", "no", "No")],
     )
     checks.value = "yes"
-    assert fh.to_xml(checks, indent=False) == (
+    assert html(checks) == html(
         '<div class="govuk-form-group">'
             '<fieldset aria-describedby="test-hint" class="govuk-fieldset">'
                 '<div data-module="govuk-checkboxes" class="govuk-checkboxes">'
@@ -913,14 +913,14 @@ def test_checkboxes_value():
         ),
     ),
 )
-def test_radio(kwargs, expected):
+def test_radio(kwargs, expected, html):
     """Test Radio with various parameters.
     Args:
         kwargs (dict): The arguments to pass to Radio.
         expected (str): The expected HTML output.
     """
     radio = ds.Radio(**kwargs)
-    assert fh.to_xml(radio, indent=False) == expected
+    assert html(radio) == html(expected)
 
 
 @pytest.mark.parametrize(
@@ -1040,7 +1040,7 @@ def test_radio(kwargs, expected):
         ),
     ),
 )
-def test_radios(kwargs, expected):
+def test_radios(kwargs, expected, html):
     """Test Radios with various parameters.
     Args:
         name (str): name to pass to Radios.
@@ -1050,17 +1050,17 @@ def test_radios(kwargs, expected):
         expected (str): The expected HTML output.
     """
     radios = ds.Radios(**kwargs)
-    assert fh.to_xml(radios, indent=False) == expected
+    assert html(radios) == html(expected)
 
 
-def test_radios_value():
+def test_radios_value(html):
     """Test Radios with value."""
     radios = ds.Radios(
         name="test",
         radios=[ds.Radio("test", "yes", "Yes"), ds.Radio("test", "no", "No")],
     )
     radios.value = "yes"
-    assert fh.to_xml(radios, indent=False) == (
+    assert html(radios) == html(
         '<div class="govuk-form-group">'
             '<fieldset aria-describedby="test-hint" class="govuk-fieldset">'
                 '<div data-module="govuk-radios" class="govuk-radios">'
@@ -1134,14 +1134,14 @@ def test_radios_value():
         ),
     ),
 )
-def test_fileupload(kwargs, expected):
+def test_fileupload(kwargs, expected, html):
     """Test FileUpload with various parameters.
     Args:
         kwargs (dict): The arguments to pass to FileUpload.
         expected (str): The expected HTML output.
     """
     fu = ds.FileUpload(**kwargs)
-    assert fh.to_xml(fu, indent=False) == expected
+    assert html(fu) == html(expected)
 
 
 @pytest.mark.parametrize(
@@ -1271,14 +1271,14 @@ def test_fileupload(kwargs, expected):
         ),
     ),
 )
-def test_date_input(kwargs, expected):
+def test_date_input(kwargs, expected, html):
     """Test DateInput with various parameters.
     Args:
         kwargs (dict): The arguments to pass to DateInput.
         expected (str): The expected HTML output.
     """
     dateinput = ds.DateInput(**kwargs)
-    assert fh.to_xml(dateinput, indent=False) == expected
+    assert html(dateinput) == html(expected)
 
 
 @pytest.mark.parametrize(
@@ -1287,21 +1287,23 @@ def test_date_input(kwargs, expected):
         (
             {},
             (
-                '<div role="region" aria-label="Cookies on Test Service" data-nosnippet id="cookie-banner" class="govuk-cookie-banner">'
-                    '<div class="govuk-cookie-banner__message govuk-width-container">'
-                        '<div class="govuk-grid-row">'
-                            '<div class="govuk-grid-column-two-thirds">'
-                                '<h2 class="govuk-heading-m">Cookies for Test Service</h2>'
-                                '<div class="govuk-cookie-banner__content"></div>'
+                "<div>"
+                    '<div role="region" aria-label="Cookies on Test Service" data-nosnippet id="cookie-banner" class="govuk-cookie-banner">'
+                        '<div class="govuk-cookie-banner__message govuk-width-container">'
+                            '<div class="govuk-grid-row">'
+                                '<div class="govuk-grid-column-two-thirds">'
+                                    '<h2 class="govuk-heading-m">Cookies for Test Service</h2>'
+                                    '<div class="govuk-cookie-banner__content"></div>'
+                                "</div>"
                             "</div>"
+                            '<form enctype="multipart/form-data" hx-post="/" hx-target="#cookie-banner">'
+                                '<div class="govuk-button-group">'
+                                    '<button type="submit" data-module="govuk-button" value="yes" name="cookies[additional]" class="govuk-button">Accept additional cookies</button>'
+                                    '<button type="submit" data-module="govuk-button" value="no" name="cookies[additional]" class="govuk-button">Reject additional cookies</button>'
+                                    '<a href="/cookies" class="govuk-link">View cookies</a>'
+                                "</div>"
+                            "</form>"
                         "</div>"
-                        '<form enctype="multipart/form-data" hx-post="/" hx-target="#cookie-banner">'
-                            '<div class="govuk-button-group">'
-                                '<button type="submit" data-module="govuk-button" value="yes" name="cookies[additional]" class="govuk-button">Accept additional cookies</button>'
-                                '<button type="submit" data-module="govuk-button" value="no" name="cookies[additional]" class="govuk-button">Reject additional cookies</button>'
-                                '<a href="/cookies" class="govuk-link">View cookies</a>'
-                            "</div>"
-                        "</form>"
                     "</div>"
                 "</div>"
             ),
@@ -1309,30 +1311,32 @@ def test_date_input(kwargs, expected):
         (
             {"confirmation": True},
             (
-                '<div role="region" aria-label="Cookies on Test Service" data-nosnippet id="cookie-banner" class="govuk-cookie-banner">'
-                    '<div class="govuk-cookie-banner__message govuk-width-container">'
-                        '<div class="govuk-grid-row">'
-                            '<div class="govuk-grid-column-two-thirds">'
-                                '<h2 class="govuk-heading-m">Cookies for Test Service</h2>'
-                                '<div class="govuk-cookie-banner__content"></div>'
+                "<div>"
+                    '<div role="region" aria-label="Cookies on Test Service" data-nosnippet id="cookie-banner" class="govuk-cookie-banner">'
+                        '<div class="govuk-cookie-banner__message govuk-width-container">'
+                            '<div class="govuk-grid-row">'
+                                '<div class="govuk-grid-column-two-thirds">'
+                                    '<h2 class="govuk-heading-m">Cookies for Test Service</h2>'
+                                    '<div class="govuk-cookie-banner__content"></div>'
+                                "</div>"
                             "</div>"
+                            '<form enctype="multipart/form-data" hx-post="/" hx-target="#cookie-banner">'
+                                '<div class="govuk-button-group">'
+                                    '<button type="submit" data-module="govuk-button" value="hide" name="cookies[additional]" class="govuk-button">Hide cookie message</button>'
+                                "</div>"
+                            "</form>"
                         "</div>"
-                        '<form enctype="multipart/form-data" hx-post="/" hx-target="#cookie-banner">'
-                            '<div class="govuk-button-group">'
-                                '<button type="submit" data-module="govuk-button" value="hide" name="cookies[additional]" class="govuk-button">Hide cookie message</button>'
-                            "</div>"
-                        "</form>"
                     "</div>"
                 "</div>"
             ),
         ),
     ),
 )
-def test_cookie_banner(kwargs, expected):
+def test_cookie_banner(kwargs, expected, html):
     """Test CookieBanner with various parameters.
     Args:
         kwargs (dict): The arguments to pass to CookieBanner.
         expected (str): The expected HTML output.
     """
-    banner = ds.CookieBanner("Test Service", **kwargs)
-    assert banner.__html__() == expected
+    banner = ds.Div(ds.CookieBanner("Test Service", **kwargs))
+    assert html(banner) == html(expected)

--- a/fast_gov_uk/tests/test_forms.py
+++ b/fast_gov_uk/tests/test_forms.py
@@ -18,7 +18,8 @@ def test_form_get_404(client):
 def test_db_form_post_valid(client, db, picture):
     data = {
         "name": "Test",
-        "gender": "male",
+        "sex": "male",
+        "gender": "yes",
         "ethnicity": "mixed",
         "dob": ["10", "10", "2000"],
         "phone": "12345",
@@ -38,7 +39,8 @@ def test_db_form_post_valid(client, db, picture):
     form_dict = json.loads(form_data)
     assert form_dict == {
         "name": "Test",
-        "gender": "male",
+        "sex": "male",
+        "gender": "yes",
         "ethnicity": "mixed",
         # This should be a date string
         "dob": "2000-10-10",
@@ -56,6 +58,11 @@ def test_db_form_post_valid(client, db, picture):
             # empty name
             {"name": ""},
             {"name": "This field is required."}
+        ),
+        (
+            # empty sex
+            {"sex": ""},
+            {"sex": "This field is required."}
         ),
         (
             # empty gender
@@ -106,7 +113,8 @@ def test_db_form_post_valid(client, db, picture):
 def test_form_post_invalid(errors, expected, client, db, picture):
     data = {
         "name": "Test",
-        "gender": "male",
+        "sex": "male",
+        "gender": "yes",
         "ethnicity": "mixed",
         "dob": ["10", "10", "2000"],
         "phone": "12345",

--- a/fast_gov_uk/tests/test_forms.py
+++ b/fast_gov_uk/tests/test_forms.py
@@ -85,9 +85,24 @@ def test_db_form_post_valid(client, db, picture):
             {"dob": "This field is required."}
         ),
         (
+            # invalid dob
+            {"dob": ["foo", "10", "2003"]},
+            {"dob": "Invalid values."}
+        ),
+        (
+            # empty picture
+            {"picture": ""},
+            {"picture": "This field is required."}
+        ),
+        (
             # empty phone
             {"phone": ""},
             {"phone": "This field is required."}
+        ),
+        (
+            # non-numeric phone
+            {"phone": "A12345"},
+            {"phone": "Value is not a number."}
         ),
         (
             # non-numeric phone


### PR DESCRIPTION
The form methods - `bind`, `clean`, `errors` etc. rely upon the fields being a linear list. Whereas at times, we need forms with fields inside `Fieldset`. 

I discovered a separate issues with the `FileUpload` field, `DateInput` field and `contrib` fields that meant they didn't deal with being left empty well. 