### PR TITLE
Notifications

### DIFF
--- a/app.py
+++ b/app.py
@@ -312,11 +312,40 @@ def equality(step=0, data=None):
 
 @fast.page
 def cookies():
+    """
+    This returns the standard GDS cookies page. E.g. -
+    https://design-system.service.gov.uk/patterns/cookies-page/full-page/
+
+    It is preset to Essential cookies but if you are using more cookies,
+    you can easily add them as follows -
+
+    ds.Cookies(
+        ds.H2("Analytical cookies")
+        ds.P("...")
+        ds.Table(...)
+    )
+
+    (See the definition of Cookies)
+    """
     return ds.Cookies()
 
 
 @fast.page
 def phase():
+    """
+    @page does not have to return a full Page. It could also
+    return snippets of html.
+
+    E.g.This returns a phase banner snippet that is inserted
+    into all the pages of the service using htmx. All you need
+    is the following -
+
+        fh.Div(hx_get="/phase", hx_trigger="load"),
+
+    This is useful for several reasons but the primary one is
+    that if your service goes Beta, you only need to update this
+    and all of the pages on your service will reflect the change.
+    """
     return ds.PhaseBanner(
         ds.Span(
             "This is a new service. Help us improve it and ",

--- a/fast_gov_uk/core.py
+++ b/fast_gov_uk/core.py
@@ -87,6 +87,7 @@ class Fast(fh.FastHTML):
             self.process_questions
         )
         self.route("/cookie-banner", methods=["GET", "POST"])(self.cookie_banner)
+        self.route("/notifications")(self.notifications)
         # Initialise notify client
         notify_key = settings["NOTIFY_API_KEY"]
         if notify_key:
@@ -215,3 +216,23 @@ class Fast(fh.FastHTML):
             return "" if hide else banner, cookie
         hide = "hide" in cookie_policy
         return "" if hide else banner
+
+    def add_notification(self, session, content, success=False):
+        notifications = session.get("notifications", [])
+        notifications.append({"title": "Success" if success else "Important", "content": content})
+        session["notifications"] = notifications
+
+    def notifications(self, session):
+        notifications = session.get("notifications", [])
+        banners = ds.Div(
+            *[
+                ds.Notification(
+                    n["content"],
+                    title=n["title"],
+                    success=(n["title"] == "Success")
+                )
+                for n in notifications
+            ]
+        )
+        session.pop("notifications", None)
+        return banners

--- a/fast_gov_uk/design_system/pages.py
+++ b/fast_gov_uk/design_system/pages.py
@@ -161,6 +161,8 @@ def Page(*content: fh.FT | Field) -> fh.FT:
             fh.Main(
                 fh.Div(
                     fh.Div(
+                        # Every page will check if there are any notifications
+                        fh.Div(hx_get="/notifications", hx_trigger="load"),
                         *content,
                         cls="govuk-grid-column-two-thirds",
                     ),

--- a/fast_gov_uk/tests/app.py
+++ b/fast_gov_uk/tests/app.py
@@ -11,7 +11,8 @@ fast = Fast({
 })
 
 @fast.page("/")
-def home():
+def home(session):
+    fast.add_notification(session, "Test")
     return ds.Page(ds.P("Hello, world!"))
 
 

--- a/fast_gov_uk/tests/app.py
+++ b/fast_gov_uk/tests/app.py
@@ -164,12 +164,6 @@ def cookies():
 
 @fast.page
 def phase():
-    """
-    This returns a phase banner partial that is inserted
-    into all the pages of the service. This means that if
-    your service goes Beta, you only need to update here
-    and all of the pages on your service will reflect this.
-    """
     return ds.PhaseBanner(
         ds.Span(
             "This is a new service. Help us improve it and ",

--- a/fast_gov_uk/tests/test_core.py
+++ b/fast_gov_uk/tests/test_core.py
@@ -31,3 +31,10 @@ def test_phase_get(client):
     response = client.get("/phase")
     assert response.status_code == 200
     assert "Alpha" in response.text
+
+
+def test_notification_get(client):
+    client.get("/")
+    response = client.get("/notifications")
+    assert response.status_code == 200
+    assert "Important" in response.text


### PR DESCRIPTION
This is the first version of toast notifications. It has 3 components - 

1. A function to add notifications - `add_notification`
2. An endpoint to render gov.uk `notification banner` component if notifications are found in `session`
3. A placeholder for notification banners in `Page`

There is more work to be done here - `add_notification` only supports text. So e.g. if your notification has anything more than plain text e.g. a heading or a link, it wouldn't work for now. 