### PR TITLE
Fix-publish-test

### DIFF
--- a/.github/workflows/publish-test.yaml
+++ b/.github/workflows/publish-test.yaml
@@ -1,20 +1,34 @@
-name: Publish to TestPyPI
+name: Publish to TestPyPI on Release
 
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+  release:
+    types: [published]  # Trigger when a new release is published
 
 permissions:
   contents: read
 
 jobs:
   publish:
+    name: Build and Publish to TestPyPI
     runs-on: ubuntu-latest
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: get_version
+        run: |
+          TAG_NAME="${GITHUB_REF##*/}"
+          VERSION="${TAG_NAME#v}"  # Remove leading 'v' if present
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Detected version: $VERSION"
+
+      - name: Update pyproject.toml with tag version
+        run: |
+          VERSION=${{ steps.get_version.outputs.version }}
+          echo "Setting project version to $VERSION"
+          sed -i "s/^version = .*/version = \"${VERSION}\"/" pyproject.toml
 
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -22,16 +36,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
 
-      - name: Install dependencies (optional)
-        run: |
-          uv pip install -e .[dev]
-
-      - name: Build the package
-        run: |
-          uv build
+      - name: Build package with uv
+        run: uv build
 
       - name: Publish to TestPyPI
         run: |
-          uv publish --repository-url https://test.pypi.org/legacy/
+          uv publish --repository-url https://test.pypi.org/fast-gov-uk/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fast-gov-uk"
-version = "0.1.0"
+version = "0.0.0" # Will be replaced by GitHub Action tag
 description = "A toolkit for rapid development of simple gov.uk services"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -245,7 +245,7 @@ wheels = [
 
 [[package]]
 name = "fast-gov-uk"
-version = "0.1.0"
+version = "0.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "notifications-python-client" },


### PR DESCRIPTION
Fix workflow to publish to test.pypi.org so that it picks up the version from release tag and not from `pyproject.toml`.