### PR TITLE
Change token to PAT

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -30,11 +30,11 @@ jobs:
         with:
           bump: ${{ steps.label.outputs.match }}
           prefix: v
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PAT_FOR_RELEASES }}
 
       - name: Create release
         id: create-release
         uses: ncipollo/release-action@v1
         with:
           tag: v${{ steps.next_version.outputs.version }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_FOR_RELEASES }}


### PR DESCRIPTION
GitHub prevents the default GITHUB_TOKEN (the one automatically available to workflows) from triggering new workflows — this is intentional, to stop infinite workflow recursion.

The release workflow needs to trigger publish workflow. In order to do this, I've added a secret to actions called `PAT_FOR_RELEASES`.