### PR TITLE
Fix publish command

### DIFF
--- a/.github/workflows/publish-test.yaml
+++ b/.github/workflows/publish-test.yaml
@@ -44,4 +44,4 @@ jobs:
         run: uv build
 
       - name: Publish to TestPyPI (trusted publishing)
-        run: uv publish --repository fast-gov-uk
+        run: uv publish --publish-url https://test.pypi.org/legacy/ --trusted-publishing always


### PR DESCRIPTION
Fix publish commend with the `publish_url` for test.pypi.org. 