### PR TITLE
Rename workflow and remove --publish-url

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -1,4 +1,4 @@
-name: Publish to TestPyPI on Tag
+name: Publish to PyPI on Tag
 
 on:
   push:
@@ -44,4 +44,4 @@ jobs:
         run: uv build
 
       - name: Publish to TestPyPI (trusted publishing)
-        run: uv publish --publish-url https://test.pypi.org/legacy/ --trusted-publishing always
+        run: uv publish --trusted-publishing always


### PR DESCRIPTION
Publish to pypi.org instead of test.pypi.org