### PR TITLE
Update license field in pyproject.toml to current spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.0" # Will be replaced by GitHub Action tag
 description = "A toolkit for rapid development of simple gov.uk services"
 readme = "README.md"
 requires-python = ">=3.12"
-license = { text = "MIT" }
+license = "MIT"
 authors = [
     { name = "Ali Zaidi", email = "alixedi@gmail.com" }
 ]


### PR DESCRIPTION
The `project.license` field in `pyproject.toml` is now [a string containing a SPDX license expression](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license). ([The spec itself](https://packaging.python.org/en/latest/specifications/pyproject-toml/#license).)

Using the new format should make PyPI show the licence slightly differently (compare https://pypi.org/project/fast-gov-uk/ with https://pypi.org/project/fastapi/).

Check that this still builds okay for you etc.