### PR TITLE
Force slash before forms and wizard urls

### DIFF
--- a/fast_gov_uk/core.py
+++ b/fast_gov_uk/core.py
@@ -255,7 +255,9 @@ class Fast(fh.FastHTML):
 
     def form(self, url=None):
         def form_decorator(func):
-            _url = url or func.__name__
+            _url = url or f"/{func.__name__}"
+            if not _url.startswith("/"):
+                raise ValueError("Routes must start with '/'")
             self.forms[_url] = func
             return func
 
@@ -269,7 +271,9 @@ class Fast(fh.FastHTML):
 
     def wizard(self, url=None):
         def wizard_decorator(func):
-            _url = url or func.__name__
+            _url = url or f"/{func.__name__}"
+            if not _url.startswith("/"):
+                raise ValueError("Routes must start with '/'")
             self.wizards[_url] = func
             return func
 
@@ -282,7 +286,7 @@ class Fast(fh.FastHTML):
         return wizard_decorator
 
     async def process_form(self, req, name: str, post: dict):
-        mkform = self.forms.get(name, None)
+        mkform = self.forms.get(f"/{name}", None)
         if not mkform:
             raise fh.HTTPException(status_code=404)
         # If GET, just return the form
@@ -300,7 +304,7 @@ class Fast(fh.FastHTML):
         self, req, session: dict, name: str, step: str, post: dict
     ):
         try:
-            mkwizard = self.wizards[name]
+            mkwizard = self.wizards[f"/{name}"]
             _step = int(step or "0")
         except (KeyError, ValueError):
             raise fh.HTTPException(status_code=404)

--- a/fast_gov_uk/tests/test_core.py
+++ b/fast_gov_uk/tests/test_core.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_home_get(client):
     response = client.get("/")
     assert response.status_code == 200
@@ -76,15 +79,15 @@ def test_form_decorator(fast, client):
     @fast.form
     def test1(data=None):
         return
-    @fast.form("foo")
+    @fast.form("/foo")
     def test2(data=None):
         return
     @fast.form()
     def test3(data=None):
         return
-    assert "test1" in fast.forms
-    assert "foo" in fast.forms
-    assert "test3" in fast.forms
+    assert "/test1" in fast.forms
+    assert "/foo" in fast.forms
+    assert "/test3" in fast.forms
     assert client.get("forms/test1").status_code == 200
     assert client.get("forms/foo").status_code == 200
     assert client.get("forms/test3").status_code == 200
@@ -95,17 +98,31 @@ def test_wizard_decorator(fast, client):
     @fast.wizard
     def test1(step=0, data=None):
         return
-    @fast.wizard("foo")
+    @fast.wizard("/foo")
     def test2(step=0, data=None):
         return
     @fast.wizard()
     def test3(step=0, data=None):
         return
-    assert "test1" in fast.wizards
-    assert "foo" in fast.wizards
-    assert "test3" in fast.wizards
+    assert "/test1" in fast.wizards
+    assert "/foo" in fast.wizards
+    assert "/test3" in fast.wizards
     assert client.get("wizards/test1", follow_redirects=True).status_code == 200
     assert client.get("wizards/foo", follow_redirects=True).status_code == 200
     assert client.get("wizards/test3", follow_redirects=True).status_code == 200
     assert client.get("wizards/foo/not-a-step", follow_redirects=True).status_code == 404
     assert client.get("bar", follow_redirects=True).status_code == 404
+
+
+def test_invalid_form_decorator(fast, client):
+    with pytest.raises(ValueError):
+        @fast.form("foo")
+        def test(data=None):
+            return
+
+
+def test_invalid_wizard_decorator(fast, client):
+    with pytest.raises(ValueError):
+        @fast.wizard("foo")
+        def test(data=None):
+            return


### PR DESCRIPTION
This was a bug in which a form (or a wizard) defined as - 

```
@fast.form("/test")
```

Would resolve to registering "/test" as the name of the form. 

As a result, in `process_forms`, when we looked for "test", we couldn't find it. 

I've now made is compulsory to define custom form and wizard urls starting with a `/`. 

This should keep it consistent with `@page` ergonomics and fix the subject bug.