### PR TITLE
Fix bug where value assigned to fields using fh.Textarea are not rendered

### DIFF
--- a/fast_gov_uk/design_system/inputs.py
+++ b/fast_gov_uk/design_system/inputs.py
@@ -328,9 +328,9 @@ class Textarea(Field):
         error_cls = " govuk-textarea--error" if self.error else ""
         return super().__ft__(
             fh.Textarea(
+                self.value,
                 name=self.name,
                 rows=self.rows,
-                value=self.value,
                 id=self._id,
                 aria_describedby=f"{self._id}-hint {self._id}-error",
                 cls=f"govuk-textarea{error_cls}",
@@ -491,9 +491,9 @@ class CharacterCount(Field):
         """
         error_cls = " govuk-textarea--error" if self.error else ""
         return fh.Textarea(
+            self.value,
             name=self.name,
             rows=self.rows,
-            value=self.value,
             id=self._id,
             aria_describedby=f"{self._id}-hint {self._id}-error",
             cls=f"govuk-textarea govuk-js-character-count{error_cls}",

--- a/fast_gov_uk/tests/design_system/test_inputs.py
+++ b/fast_gov_uk/tests/design_system/test_inputs.py
@@ -1527,3 +1527,15 @@ async def test_clean_with_invalid_values(field, value):
         f = field(name="test", label="Test Label", choices={"test1": "Test 1", "test2": "Test 2"})
         f.value = value
         await f.clean
+
+
+@pytest.mark.parametrize("field", (
+    ds.Textarea,
+    ds.CharacterCount,
+
+))
+def test_value(field, html):
+    """Test that textarea fields can be assigned values."""
+    f = field(name="test", label="Test Label", required=False)
+    f.value = "test"
+    assert f">test</textarea>" in html(f)

--- a/fast_gov_uk/tests/design_system/test_inputs.py
+++ b/fast_gov_uk/tests/design_system/test_inputs.py
@@ -1538,4 +1538,4 @@ def test_value(field, html):
     """Test that textarea fields can be assigned values."""
     f = field(name="test", label="Test Label", required=False)
     f.value = "test"
-    assert f">test</textarea>" in html(f)
+    assert ">test</textarea>" in html(f)


### PR DESCRIPTION
This was because assigning values to `Textarea` is done like -

```
<textarea>test-value</textarea>
```

Instead of -

```
<textarea value="test-value">
```
