### PR TITLE
Change Panel content to be a str

### DIFF
--- a/fast_gov_uk/design_system/components.py
+++ b/fast_gov_uk/design_system/components.py
@@ -80,7 +80,7 @@ def Detail(
 
 
 def Panel(
-    *content: fh.FT | str,
+    content: str,
     title: str = "",
     **kwargs,
 ) -> fh.FT:
@@ -97,8 +97,18 @@ def Panel(
         # | Panel content.
         # -----------------------
 
+    The Panel content argument is a string but sometimes, it is useful to
+    have HTML tags in there. Here is an example on how to do that -
+
+        >>> panel = ds.Panel(ds.Safe"<strong>Panel content</strong>"), title="Test")
+        # Renders panel component with title and bold content.
+        # -----------------------
+        # | Test
+        # | *Panel content*
+        # -----------------------
+
     Args:
-        *content (FT or str): The content to display in the panel.
+        content (str): The content to display in the panel.
         title (str, optional): The title of the panel. Defaults to "".
         **kwargs: Additional keyword arguments.
 
@@ -109,7 +119,7 @@ def Panel(
     """
     return fh.Div(
         fh.H1(title, cls="govuk-panel__title") if title else "",
-        fh.Div(*content, cls="govuk-panel__body"),
+        fh.Div(content, cls="govuk-panel__body"),
         cls="govuk-panel govuk-panel--confirmation",
         **kwargs,
     )

--- a/fast_gov_uk/tests/design_system/test_components.py
+++ b/fast_gov_uk/tests/design_system/test_components.py
@@ -82,43 +82,43 @@ def test_detail(content, expected, html):
     "kwargs, expected",
     (
         (
-            {"content": [ds.P("Test Content")]},
+            {"content": "Test Content"},
             (
                 '<div class="govuk-panel govuk-panel--confirmation">'
                     '<div class="govuk-panel__body">'
-                        '<p class="govuk-body">Test Content</p>'
+                        'Test Content'
                     '</div>'
                 '</div>'
             ),
         ),
         (
-            {"title": "Test", "content": [ds.P("Test Content")]},
+            {"title": "Test", "content": "Test Content"},
             (
                 '<div class="govuk-panel govuk-panel--confirmation">'
                     '<h1 class="govuk-panel__title">Test</h1>'
                     '<div class="govuk-panel__body">'
-                        '<p class="govuk-body">Test Content</p>'
+                        'Test Content'
                     '</div>'
                 '</div>'
             ),
         ),
         (
-            {"content": [ds.A("Test Link")]},
+            {"content": ds.Safe("<a href='#'>Test Link</a>")},
             (
                 '<div class="govuk-panel govuk-panel--confirmation">'
                     '<div class="govuk-panel__body">'
-                        '<a href="#" class="govuk-link">Test Link</a>'
+                        '<a href="#">Test Link</a>'
                     '</div>'
                 '</div>'
             ),
         ),
         (
-            {"content": [ds.A("Test Link"), ds.P("Test Content")]},
+            {"content": ds.Safe("<a href='#'>Test Link</a> Test Content")},
             (
                 '<div class="govuk-panel govuk-panel--confirmation">'
                     '<div class="govuk-panel__body">'
-                        '<a href="#" class="govuk-link">Test Link</a>'
-                        '<p class="govuk-body">Test Content</p>'
+                        '<a href="#">Test Link</a>'
+                        'Test Content'
                     '</div>'
                 '</div>'
             ),
@@ -132,7 +132,7 @@ def test_panel(kwargs, expected, html):
         expected (str): The expected HTML output.
     """
     content = kwargs.pop("content")
-    panel = ds.Panel(*content, **kwargs)
+    panel = ds.Panel(content, **kwargs)
     assert html(panel) == html(expected)
 
 
@@ -654,7 +654,7 @@ def test_summary_card(args, expected, html):
 @pytest.mark.parametrize("component", (
     ds.Inset("test", hx_test="foo"),
     ds.Detail("test", hx_test="foo"),
-    ds.Panel(hx_test="foo"),
+    ds.Panel("test", hx_test="foo"),
     ds.Tag("test", hx_test="foo"),
     ds.Warning(hx_test="foo"),
     ds.Notification(hx_test="foo"),


### PR DESCRIPTION
This was necessary b/c otherwise, passing in e.g. `ds.P` meant that the para inside the panel had `govuk-body` class. This made the text black whereas the text inside a panel should be white.

This is not a perfect solution b/c sometimes, content would need some tags. I have included an example on how to do that with `ds.Safe`.