### PR TITLE
Add docs for the url where forms and wizards are rendered.

### DIFF
--- a/docs/scaffolding/forms.rst
+++ b/docs/scaffolding/forms.rst
@@ -57,7 +57,7 @@ The following is how you would build this feedback form in fast-gov-uk -
 
 1. The ``form`` decorator "registers" feedback function as a form rendered at
 ``/forms/feeback``. You can easily render this form at a different url -
-``@fast.form("/not-feedback")``.
+``@fast.form("/not-feedback")`` will render the form at ``/forms/not-feedback``.
 
 2. The ``feedback`` function must return a ``Form`` object (see below) and it must accept
 a ``data`` argument because forms can be empty or filled and when they are filled, the

--- a/docs/scaffolding/wizards.rst
+++ b/docs/scaffolding/wizards.rst
@@ -79,7 +79,7 @@ The following is a simplified implementation of the
 
 1. The ``wizard`` decorator "registers" this function as a wizard rendered at
 ``/wizards/equality``. You can easily render this at a different url -
-``@fast.wizard("/not-equality")``.
+``@fast.wizard("/not-equality")`` would render the wizard at ``/wizards/not-equality``.
 
 2. The ``equality`` function must return a ``Wizard`` object (see below) and it must accept
 ``step`` and ``data`` arguments. You can think of Wizards as a series of Forms. The ``step``

--- a/fast_gov_uk/forms.py
+++ b/fast_gov_uk/forms.py
@@ -390,6 +390,12 @@ class Form:
         ...     cta="Send",
         ... )
 
+    If you are using a ``@fast.form`` decorator on a method that returns
+    a form, the form will be rendered at ``/forms/<function_name>``.
+
+    If you are specifying a url in your decorator e.g. ``@fast.form("test")``,
+    the form will be rendered at ``/forms/test``.
+
     Args:
         name (str): Name of the Form.
         backends (list): List of backends to process submitted data.
@@ -624,6 +630,12 @@ class Wizard:
     """
     Implements the question-protocol aka Wizard i.e. forms that step
     through the fields one at a time.
+
+    If you are using a ``@fast.wizard`` decorator on a method that returns
+    a wizard, the wizard will be rendered at ``/wizards/<function_name>``.
+
+    If you are specifying a url in your decorator e.g. ``@fast.wizard("test")``,
+    the wizard will be rendered at ``/wizards/test``.
 
     Examples:
         >>> wizard = Wizard(


### PR DESCRIPTION
This is mostly for AI agents. I noticed that when I asked an agent to implement a wizard, it kept looking for it in `/wizard/foo` instead of `/wizards/foo`.

As they do, at that point the agent went completely off the rails and ditched the decorator.