### PR TITLE
Clean up session after saving data for processing.

### DIFF
--- a/fast_gov_uk/forms.py
+++ b/fast_gov_uk/forms.py
@@ -712,7 +712,9 @@ class Wizard:
         Returns:
             fh.Redirect: Redirect response to success URL.
         """
+        # Save the data and clean up the session
         data = req.session[self.name]["data"]
+        del req.session[self.name]
         try:
             for backend in self.backends:
                 await backend.process(req, self.name, data, *args, **kwargs)


### PR DESCRIPTION
There is a regression in `mini_euqality` - when I don't give permission for the survey and the wizard gets processed, I am seeing what are presumably stale values for fields that follow permission whereas actually, these fields should be empty.
